### PR TITLE
Handle edge case in dynamical system

### DIFF
--- a/tensorpr3.m
+++ b/tensorpr3.m
@@ -516,7 +516,7 @@ classdef tensorpr3
                 end
                 xn = X(:,1);
                 % make sure it's positive
-		        [~, max_abs_ind] = max(abs(xn));
+                [~, max_abs_ind] = max(abs(xn));
                 xn = xn*sign(xn(max_abs_ind));
             end
             xn = xn / norm(xn, 1);

--- a/tensorpr3.m
+++ b/tensorpr3.m
@@ -516,7 +516,7 @@ classdef tensorpr3
                 end
                 xn = X(:,1);
                 % make sure it's positive
-		[~, max_abs_ind] = max(abs(xn));
+		        [~, max_abs_ind] = max(abs(xn));
                 xn = xn*sign(xn(max_abs_ind));
             end
             xn = xn / norm(xn, 1);

--- a/tensorpr3.m
+++ b/tensorpr3.m
@@ -515,7 +515,9 @@ classdef tensorpr3
                     error('non-unique stationary distribution');
                 end
                 xn = X(:,1);
-                xn = xn*sign(xn(1)); % make sure it's positive
+                % make sure it's positive
+		[~, max_abs_ind] = max(abs(xn));
+                xn = xn*sign(xn(max_abs_ind));
             end
             xn = xn / norm(xn, 1);
             


### PR DESCRIPTION
If the Perron vector xn has a zero entry in the first entry, then using xn(1) to grab the sign will zero out the vector.
